### PR TITLE
Fixes notifying wrong cpu/gpu level after changing scene.

### DIFF
--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.h
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.h
@@ -61,13 +61,13 @@ public:
 private:
     static void notifyContinuousFrameLost(int frameLostCycle, int continueFrameLostThreshold, int times);
     static void notifyLowFps(int lowFpsCycle, float lowFpsThreshold, int frames);
+    static void notifyGameStatusIfCpuOrGpuLevelChanged();
 
     static void calculateFrameLost();
     static void getCpuAndGpuLevel(int* cpuLevel, int* gpuLevel);
 
     static void onBeforeSetNextScene(EventCustom* event);
-    static void onAfterSetNextScene(EventCustom* event);
-    static void onAfterVisitScene(EventCustom* event);
+    static void onAfterDrawScene(EventCustom* event);
     static void onEnterForeground(EventCustom* event);
 
     static int getTotalParticleCount();


### PR DESCRIPTION
- We need to hack `AfterDrawScene` event to calculate cpu/gpu level rather than `AfterVisit` since `vertex count` & `draw call count`  are only updated after rendering.
  Also 
- adds the feature that notifying cpu/gpu level to system after game come back to foreground and ignore whether cpu/level has been changed.
- _oldCpuLevel, _oldGpuLevel variables should be initialized with -1, and should be reset to -1 while we wanna force notify status to system.
