### PR TITLE
Reverts nativeOnqueryFps, return expectedFps is which developer set.

### DIFF
--- a/cocos2dx/actions/CCActionManager.cpp
+++ b/cocos2dx/actions/CCActionManager.cpp
@@ -337,7 +337,7 @@ unsigned int CCActionManager::numberOfRunningActionsInTarget(CCObject *pTarget)
 
 unsigned int CCActionManager::numberOfRunningActions() const
 {
-    ssize_t count = 0;
+    unsigned int count = 0;
     struct _hashElement* element = NULL;
     struct _hashElement* tmp = NULL;
     HASH_ITER(hh, m_pTargets, element, tmp)

--- a/cocos2dx/base_nodes/CCNode.cpp
+++ b/cocos2dx/base_nodes/CCNode.cpp
@@ -1333,6 +1333,11 @@ void CCNode::removeAllComponents()
     m_pComponentContainer->removeAll();
 }
 
+int CCNode::getAttachedNodeCount()
+{
+    return s_attachedNodeCount;
+}
+
 // CCNodeRGBA
 CCNodeRGBA::CCNodeRGBA()
 : _displayedOpacity(255)

--- a/cocos2dx/base_nodes/CCNode.h
+++ b/cocos2dx/base_nodes/CCNode.h
@@ -158,7 +158,7 @@ public:
     /**
      * Gets count of nodes those are attached to scene graph.
      */
-    static int getAttachedNodeCount() { return s_attachedNodeCount; }
+    static int getAttachedNodeCount();
     
     /**
      * Gets the description string. It makes debugging easier.

--- a/cocos2dx/particle_nodes/CCParticleSystem.cpp
+++ b/cocos2dx/particle_nodes/CCParticleSystem.cpp
@@ -1369,6 +1369,15 @@ void CCParticleSystem::setScaleY(float newScaleY)
     CCNode::setScaleY(newScaleY);
 }
 
+std::vector<CCParticleSystem*>& CCParticleSystem::getAllParticleSystems()
+{
+    return g_allInstances;
+}
+
+void CCParticleSystem::setTotalParticleCountFactor(float factor)
+{
+    g_totalParticleCountFactor = factor;
+}
 
 NS_CC_END
 

--- a/cocos2dx/particle_nodes/CCParticleSystem.h
+++ b/cocos2dx/particle_nodes/CCParticleSystem.h
@@ -435,12 +435,12 @@ public:
 
     /** Gets all ParticleSystem references
      */
-    static std::vector<CCParticleSystem*>& getAllParticleSystems() { return g_allInstances; }
+    static std::vector<CCParticleSystem*>& getAllParticleSystems();
 
 private:
     friend class EngineDataManager;
     /** Internal use only, it's used by EngineDataManager class for Android platform */
-    static void setTotalParticleCountFactor(float factor) { g_totalParticleCountFactor = factor; }
+    static void setTotalParticleCountFactor(float factor);
 
 protected:
     virtual void updateBlendFunc();

--- a/cocos2dx/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
+++ b/cocos2dx/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
@@ -1180,12 +1180,14 @@ void EngineDataManager::nativeOnQueryFps(JNIEnv* env, jobject thiz, jintArray ar
 
     if (arrLenExpectedFps > 0 && arrLenRealFps > 0)
     {
+        CCDirector* director = cocos2d::CCDirector::sharedDirector();
         jboolean isCopy = JNI_FALSE;
         jint* expectedFps = env->GetIntArrayElements(arrExpectedFps, &isCopy);
-        *expectedFps = (int)std::ceil(1.0f / _animationInterval);
+        float animationInterval = director->getAnimationInterval();
+        *expectedFps = (int)std::ceil(1.0f / animationInterval);
         
         jint* realFps = env->GetIntArrayElements(arrRealFps, &isCopy);
-        *realFps = (int)std::ceil(cocos2d::CCDirector::sharedDirector()->getFrameRate());
+        *realFps = (int)std::ceil(director->getFrameRate());
 
         // Log before expectedFps & realFps is released.
         LOGD("nativeOnQueryFps, realFps: %d, expected: %d", *realFps, *expectedFps);

--- a/cocos2dx/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
+++ b/cocos2dx/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
@@ -645,11 +645,13 @@ void EngineDataManager::calculateFrameLost()
         {
             _lastFrameLost100msUpdate = now;
             // check lost frame count
-            if (_frameLostCounter > _continuousFrameLostThreshold)
+            if (_frameLostCounter >= _continuousFrameLostThreshold)
             {
-                _frameLostCounter = 0;
                 ++_continuousFrameLostCount;
             }
+            // Reset frame lost counter after 100ms interval 
+            // even it's smaller than _continuousFrameLostThreshold
+            _frameLostCounter = 0;
         }
         
         interval = getInterval(now, _lastContinuousFrameLostUpdate);


### PR DESCRIPTION
Continuous frame lost logic fix. Reset frame lost counter after 100ms interval  even it's smaller than _continuousFrameLostThreshold.