### PR TITLE
Reverts nativeOnqueryFps, return expectedFps is which developer set.

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -2179,6 +2179,11 @@ void Node::setCameraMask(unsigned short mask, bool applyChildren)
     }
 }
 
+int Node::getAttachedNodeCount()
+{
+    return __attachedNodeCount;
+}
+
 // MARK: Deprecated
 
 __NodeRGBA::__NodeRGBA()

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -130,7 +130,7 @@ public:
     /**
      * Gets count of nodes those are attached to scene graph.
      */
-    static int getAttachedNodeCount() { return __attachedNodeCount; }
+    static int getAttachedNodeCount();
 public:
     
     /**

--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -271,6 +271,11 @@ Vector<ParticleSystem*>& ParticleSystem::getAllParticleSystems()
     return __allInstances;
 }
 
+void ParticleSystem::setTotalParticleCountFactor(float factor)
+{
+    __totalParticleCountFactor = factor;
+}
+
 bool ParticleSystem::init()
 {
     return initWithTotalParticles(150);

--- a/cocos/2d/CCParticleSystem.h
+++ b/cocos/2d/CCParticleSystem.h
@@ -823,7 +823,7 @@ protected:
 private:
     friend class EngineDataManager;
     /** Internal use only, it's used by EngineDataManager class for Android platform */
-    static void setTotalParticleCountFactor(float factor) { __totalParticleCountFactor = factor; }
+    static void setTotalParticleCountFactor(float factor);
     
 protected:
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
@@ -595,11 +595,13 @@ void EngineDataManager::calculateFrameLost()
         {
             _lastFrameLost100msUpdate = now;
             // check lost frame count
-            if (_frameLostCounter > _continuousFrameLostThreshold)
+            if (_frameLostCounter >= _continuousFrameLostThreshold)
             {
-                _frameLostCounter = 0;
                 ++_continuousFrameLostCount;
             }
+            // Reset frame lost counter after 100ms interval 
+            // even it's smaller than _continuousFrameLostThreshold
+            _frameLostCounter = 0;
         }
         
         interval = std::chrono::duration_cast<std::chrono::microseconds>(now - _lastContinuousFrameLostUpdate).count() / 1000000.0f;
@@ -1120,12 +1122,14 @@ void EngineDataManager::nativeOnQueryFps(JNIEnv* env, jobject thiz, jintArray ar
 
     if (arrLenExpectedFps > 0 && arrLenRealFps > 0)
     {
+        Director* director = Director::getInstance();
         jboolean isCopy = JNI_FALSE;
         jint* expectedFps = env->GetIntArrayElements(arrExpectedFps, &isCopy);
-        *expectedFps = (int)std::ceil(1.0f / _animationInterval);
+        float animationInterval = director->getAnimationInterval();
+        *expectedFps = (int)std::ceil(1.0f / animationInterval);
         
         jint* realFps = env->GetIntArrayElements(arrRealFps, &isCopy);
-        *realFps = (int)std::ceil(Director::getInstance()->getFrameRate());
+        *realFps = (int)std::ceil(director->getFrameRate());
 
         // Log before expectedFps & realFps is released.
         LOGD("nativeOnQueryFps, realFps: %d, expected: %d", *realFps, *expectedFps);


### PR DESCRIPTION
Continuous frame lost logic fix. Reset frame lost counter after 100ms interval even it's smaller than _continuousFrameLostThreshold.